### PR TITLE
Simplify implied distribution rules

### DIFF
--- a/Example/ParalayoutSnapshotTests/ViewDistributionSnapshotTests.swift
+++ b/Example/ParalayoutSnapshotTests/ViewDistributionSnapshotTests.swift
@@ -39,9 +39,13 @@ final class ViewDistributionSnapshotTests: SnapshotTestCase {
 
         containerView.applyVerticalSubviewDistribution(
             [
+                1.flexible,
                 firstView,
+                1.flexible,
                 secondView,
+                1.flexible,
                 thirdView,
+                1.flexible,
             ]
         )
         assertSnapshot(matching: containerView, as: .image, named: nameForSnapshot(with: ["vertical"]))
@@ -67,9 +71,13 @@ final class ViewDistributionSnapshotTests: SnapshotTestCase {
 
         containerView.applyVerticalSubviewDistribution(
             [
+                1.flexible,
                 firstView,
+                1.flexible,
                 secondView,
+                1.flexible,
                 thirdView,
+                1.flexible,
             ]
         )
         assertSnapshot(matching: containerView, as: .image, named: nameForSnapshot(with: []))
@@ -178,9 +186,13 @@ final class ViewDistributionSnapshotTests: SnapshotTestCase {
 
                 applyHorizontalSubviewDistribution(
                     [
+                        1.flexible,
                         label1.distributionItemUsingCapInsets,
+                        1.flexible,
                         label2.distributionItemUsingCapInsets,
+                        1.flexible,
                         label3.distributionItemUsingCapInsets,
+                        1.flexible,
                     ],
                     inRect: bounds.insetBy(bottom: 8),
                     orthogonalAlignment: .bottom(inset: 0)

--- a/Paralayout/UIView+Distribution.swift
+++ b/Paralayout/UIView+Distribution.swift
@@ -66,10 +66,8 @@ extension UIView {
 
     /// Arranges subviews along the vertical axis according to a distribution with fixed and/or flexible spacers.
     ///
-    /// * If there are no flexible elements, this will treat the distribution as vertically centered (i.e. with two
+    /// If there are no flexible elements, this will treat the distribution as vertically centered (i.e. with two
     /// flexible elements of equal weight at the top and bottom, respectively).
-    /// * If there are no spacers (fixed or flexible), this will treat the distribution as equal flexible spacing
-    /// at the top, bottom, and between each view.
     ///
     /// **Examples:**
     ///
@@ -81,8 +79,7 @@ extension UIView {
     ///
     /// To evenly spread out items:
     /// ```
-    /// // This is effectively the same as [ 1.flexible, button1, 1.flexible, button2, 1.flexible, button3 ].
-    /// applyVerticalSubviewDistribution([ button1, button2, button3 ])
+    /// applyVerticalSubviewDistribution([ 1.flexible, button1, 1.flexible, button2, 1.flexible, button3, 1.flexible ])
     /// ```
     ///
     /// To stack two elements with 50% more space below than above:
@@ -153,10 +150,8 @@ extension UIView {
 #if swift(>=5.4)
     /// Arranges subviews along the vertical axis according to a distribution with fixed and/or flexible spacers.
     ///
-    /// * If there are no flexible elements, this will treat the distribution as vertically centered (i.e. with two
+    /// If there are no flexible elements, this will treat the distribution as vertically centered (i.e. with two
     /// flexible elements of equal weight at the top and bottom, respectively).
-    /// * If there are no spacers (fixed or flexible), this will treat the distribution as equal flexible spacing
-    /// at the top, bottom, and between each view.
     ///
     /// **Examples:**
     ///
@@ -172,11 +167,14 @@ extension UIView {
     ///
     /// To evenly spread out items:
     /// ```swift
-    /// // This is effectively the same as [ 1.flexible, button1, 1.flexible, button2, 1.flexible, button3 ].
     /// applyVerticalSubviewDistribution {
+    ///     1.flexible
     ///     button1
+    ///     1.flexible
     ///     button2
+    ///     1.flexible
     ///     button3
+    ///     1.flexible
     /// }
     /// ```
     ///
@@ -255,10 +253,8 @@ extension UIView {
 
     /// Arranges subviews along the horizontal axis according to a distribution with fixed and/or flexible spacers.
     ///
-    /// * If there are no flexible elements, this will treat the distribution as horizontally centered (i.e. with two
+    /// If there are no flexible elements, this will treat the distribution as horizontally centered (i.e. with two
     /// flexible elements of equal weight at the leading and trailing edges, respectively).
-    /// * If there are no spacers (fixed or flexible), this will treat the distribution as equal flexible spacing
-    /// at the leading edge, trailing edge, and between each view.
     ///
     /// **Examples:**
     ///
@@ -270,8 +266,7 @@ extension UIView {
     ///
     /// To evenly spread out items:
     /// ```
-    /// // This is effectively the same as [ 1.flexible, button1, 1.flexible, button2, 1.flexible, button3 ].
-    /// applyHorizontalSubviewDistribution([ button1, button2, button3 ])
+    /// applyHorizontalSubviewDistribution([ 1.flexible, button1, 1.flexible, button2, 1.flexible, button3 ])
     /// ```
     ///
     /// To stack two elements with 50% more space after than before:
@@ -335,10 +330,8 @@ extension UIView {
 #if swift(>=5.4)
     /// Arranges subviews along the horizontal axis according to a distribution with fixed and/or flexible spacers.
     ///
-    /// * If there are no flexible elements, this will treat the distribution as horizontally centered (i.e. with two
+    /// If there are no flexible elements, this will treat the distribution as horizontally centered (i.e. with two
     /// flexible elements of equal weight at the leading and trailing edges, respectively).
-    /// * If there are no spacers (fixed or flexible), this will treat the distribution as equal flexible spacing
-    /// at the leading edge, trailing edge, and between each view.
     ///
     /// **Examples:**
     ///
@@ -354,11 +347,14 @@ extension UIView {
     ///
     /// To evenly spread out items:
     /// ```swift
-    /// // This is effectively the same as [ 1.flexible, button1, 1.flexible, button2, 1.flexible, button3 ].
     /// applyHorizontalSubviewDistribution {
+    ///     1.flexible
     ///     button1
+    ///     1.flexible
     ///     button2
+    ///     1.flexible
     ///     button3
+    ///     1.flexible
     /// }
     /// ```
     ///


### PR DESCRIPTION
Previously we had two rules for implied distribution items:

1. If there are no spacers in the distribution, treat it as evenly spaced. In order words, it basically treats an array of just views as having a `1.flexible` at the start, end, and between each view.
2. If there are no flexible spacers (so only fixed spacers) in the distribution, the extra space goes at the outside of the distribution. In order words, it adds a `1.flexible` to the start and end of the array.

The second rule is necessary since we need to do _something_ when there are no flexible elements. The first rule, however, is simply a convenience. But in practice, it's turned out to be more overhead to remember when using distributions than actually convenient.

This PRs removes rule 1, so a distribution with no spacers will simply get equal-weight flexible spacers inserted at the start and end of the distribution. To make it a little easier to get the original behavior, I also added the `interspersed` convenience here, so you can do:

```swift
applyVerticalSubviewDistribution {
    1.flexible
    distributedViews.interspersed(with: 1.flexible)
    1.flexible
}
```