### PR TITLE
Normalize untransformed frames to avoid offsetting bounds.origin

### DIFF
--- a/Paralayout/UIView+Frame.swift
+++ b/Paralayout/UIView+Frame.swift
@@ -25,6 +25,9 @@ extension UIView {
     ///
     /// This rect is always well-defined, regardless of any transform that has been applied to the view, and so is safe
     /// to use even when `frame` is not.
+    ///
+    /// - Note: Rects will be normalized such that the absolute value of their size is maintained. In other words, setting a size with a negative value on one or
+    /// more dimension will cause your untransformed frame's origin to shift in order to take up the same equivalent rect in space.
     public var untransformedFrame: CGRect {
         get {
             return CGRect(
@@ -36,10 +39,11 @@ extension UIView {
             )
         }
         set {
-            bounds.size = newValue.size
+            let newSize = CGSize(width: abs(newValue.width), height: abs(newValue.height))
+            bounds.size = newSize
             center = CGPoint(
-                x: newValue.minX + newValue.width * layer.anchorPoint.x,
-                y: newValue.minY + newValue.height * layer.anchorPoint.y
+                x: newValue.minX + newSize.width * layer.anchorPoint.x,
+                y: newValue.minY + newSize.height * layer.anchorPoint.y
             )
         }
     }

--- a/ParalayoutTests/UIViewFrameTests.swift
+++ b/ParalayoutTests/UIViewFrameTests.swift
@@ -47,6 +47,14 @@ final class UIViewFrameTests: XCTestCase {
     }
 
     @MainActor
+    func testUntransformedFrameSetter_negativeSize() {
+        let view = UIView()
+
+        view.untransformedFrame = CGRect(x: 80, y: 70, width: -60, height: -50)
+        XCTAssertEqual(view.untransformedFrame, CGRect(x: 20, y: 20, width: 60, height: 50))
+    }
+
+    @MainActor
     func testUntransformedFrameGetter_nonIdentityTransform() {
         let view = UIView(frame: CGRect(x: 10, y: 20, width: 30, height: 40))
 


### PR DESCRIPTION
We now do the same normalization that `UIView.bounds` and `UIView.frame` do under the hood. By doing the normalization ourselves, we avoid shifting our `bounds.origin` if a negative size is assigned.